### PR TITLE
fix(ETR-46): JSON 응답 필드명을 Java Entity와 일치하도록 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,6 +106,7 @@ def fgsm_attack_with_blur(image_tensor, model, base_epsilon=0.015, base_sigma=0.
     attack_success = pred.item() != adv_pred.item()
     confidence_drop = conf.item() - adv_conf.item()
     
+    # Java Entity와 매핑
     return {
         'original_class': original_class,
         'adversarial_class': adversarial_class,


### PR DESCRIPTION
## 📝 Summary
- originalFilePath, processedFilePath로 필드명 변경
- camelCase 적용 (attackSuccess, originalPrediction 등)
- epsilon 필드 추가하여 Entity 매핑 완료

## 💻 Describe your changes
> ![image](https://github.com/user-attachments/assets/67896c1f-ffa2-4a36-a8b9-afcf4dde988e)

## #️⃣ Issue number and link
> #6

## 💬 Message to the Reviewer
